### PR TITLE
Add Cate to AI-Powered & Next-Gen IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These IDEs are built with Artificial Intelligence at their core or represent the
 | <img src="Resources/Icons/v0.png" alt="icon" width=15 height=15> **v0** | Generative UI system by Vercel. React + Tailwind CSS generation. | [Website](https://v0.dev) | `Web` | Freemium | `UI-Gen` `React` |
 | <img src="Resources/Icons/jetbrains-fleet.svg" alt="icon" width=15 height=15> **JetBrains Fleet** | A distributed, polyglot IDE built from scratch by JetBrains. Uses the IntelliJ engine but with a lightweight UI. | [Website](https://www.jetbrains.com/fleet) | `Mac` `Windows` `Linux` | Freemium, Proprietary | `Distributed` `Polyglot` |
 | <img src="Resources/Icons/nimbalyst.png" alt="icon" width=15 height=15> **Nimbalyst** | Visual workspace for building with Claude Code and Codex. Session and task management. Visual editing. | [Website](https://nimbalyst.com) | `Mac` `Windows` `Linux` | Freemium, Proprietary | `Agent Manager` `Visual Editor` |
+| **Cate** | Infinite-canvas IDE where editors, terminals, browsers, docs, Git panels and AI agents float as draggable nodes you arrange freely, like Figma for code. Run multiple Claude Code agents in parallel on the canvas. | [Github](https://github.com/0-AI-UG/cate) | `Mac` `Windows` `Linux` | Free, Open-Source | `Infinite-Canvas` `AI-Integrated` |
 
 ## General Purpose IDEs
 


### PR DESCRIPTION
Adds [Cate](https://github.com/0-AI-UG/cate) to the **AI-Powered & Next-Gen IDEs** section.

Cate is an open-source desktop IDE built on an infinite zoomable canvas. Editors, terminals, browsers, docs, Git panels and AI agents float as draggable nodes you arrange freely, like Figma for code. You can run multiple Claude Code agents in parallel directly on the canvas.

- License: MIT (Free, Open-Source)
- Platforms: macOS, Windows, Linux
- Repo: https://github.com/0-AI-UG/cate

Entry follows the table format from CONTRIBUTING. I left the icon cell out since I did not want to commit a logo file into Resources/Icons without your preference; happy to add `cate.png` if you would like (the project logo is an SVG at `assets/cate-logo.svg`).
